### PR TITLE
feat: add support for writing to GITHUB_OUTPUT file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,12 +34,23 @@ if [[ -n "$CHANGED_FILES" ]]; then
   echo "Found uncommited changes"
 
   CHANGED_FILES=$(echo "$CHANGED_FILES" | awk '{gsub(/\|/,"\n"); print $0;}' | awk -v d="$INPUT_SEPARATOR" '{s=(NR==1?s:s d)$0}END{print s}')
-
-  echo "::set-output name=files_changed::true"
-  echo "::set-output name=changed_files::$CHANGED_FILES"
+  
+  if [[ -z "$GITHUB_OUTPUT" ]]; then
+    echo "::set-output name=files_changed::true"
+    echo "::set-output name=changed_files::$CHANGED_FILES"
+  else
+    echo "files_changed=true" >> "$GITHUB_OUTPUT"
+    echo "changed_files=$CHANGED_FILES" >> "$GITHUB_OUTPUT"
+  fi
+  
 else
   echo "No changes found."
-  echo "::set-output name=files_changed::false"
+  
+  if [[ -z "$GITHUB_OUTPUT" ]]; then
+    echo "::set-output name=files_changed::false"
+  else
+    echo "files_changed=false" >> "$GITHUB_OUTPUT"
+  fi
 fi
 
 echo "::endgroup::"


### PR DESCRIPTION
[::set-output is being deprecated soon and >>$GITHUB_OUTPUT will work as of runner version 2.297.0](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)